### PR TITLE
Formatar conteúdo das requisições à API como UTF-8

### DIFF
--- a/src/main/java/br/com/totalvoice/TotalVoiceClient.java
+++ b/src/main/java/br/com/totalvoice/TotalVoiceClient.java
@@ -49,14 +49,14 @@ public class TotalVoiceClient implements ClientInterface {
     @Override
     public JSONObject post(RequestInterface request, JSONObject data) throws Exception {
         HttpPost post = new HttpPost(baseUrl + request.getURL());
-        post.setEntity(new StringEntity(data.toString()));
+        post.setEntity(new StringEntity(data.toString(), "UTF-8"));
         return execute(post);
     }
 
     @Override
     public JSONObject put(RequestInterface request, JSONObject data) throws Exception {
         HttpPut put = new HttpPut(baseUrl + request.getURL());
-        put.setEntity(new StringEntity(data.toString()));
+        put.setEntity(new StringEntity(data.toString(), "UTF-8"));
         return execute(put);
     }
 


### PR DESCRIPTION
O JSON da requisição é enviado ao servidor usando o encoding padrão ISO-8859-1 da classe StringEntity.
A RFC 8259 especifica que o encoding padrão do JSON é o UTF-8.

O resultado é que TTS com mensagens contendo caracteres especiais não são entregues como deveriam:
![image](https://github.com/totalvoice/totalvoice-java/assets/5123733/b29ce5f6-4eff-4554-baaa-4abe3dea9540)

Nos endpoints legados apiX.totalvoice.com.br isso causa uma resposta 502 Bad Gateway do servidor.
No novo endpoint voice-api.zenvia.com as chamadas TTS são ditas com uma pausa na voz do bot onde deveria haver acentos.